### PR TITLE
Update Terraform Apply job condition in workflow

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -95,7 +95,7 @@ jobs:
     name: Terraform Apply
     runs-on: ubuntu-latest
     environment: dev
-    if: github.ref == 'refs/heads/main' && (github.event.pull_request.merged == true || github.event_name == 'push') && needs.check-bucket.outputs.bucket-exists == 'false'
+    if: github.ref == 'refs/heads/main' && (github.event.pull_request.merged == true || github.event_name == 'push')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Removed the dependency on the 'check-bucket' job output for the Terraform Apply job. The job now runs on pushes or merged pull requests to main without checking if the bucket exists.