### PR TITLE
Disable special characters in generated passwords

### DIFF
--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -80,9 +80,8 @@ data "aws_caller_identity" "current" {}
 
 # Random Password Generation
 resource "random_password" "postgres_password" {
-  length           = 16
-  special          = true
-  override_special = "/@\"'\\" # Override to avoid issues with certain special characters
+  length  = 16
+  special = false
 }
 
 resource "random_password" "redis_password" {
@@ -91,14 +90,13 @@ resource "random_password" "redis_password" {
 }
 
 resource "random_password" "mysql_password" {
-  length           = 16
-  special          = true
-  override_special = "/@\"'\\" # Override to avoid issues with certain special characters
+  length  = 16
+  special = false
 }
 
 resource "random_password" "rabbitmq_password" {
   length  = 16
-  special = true
+  special = false
 }
 
 # VPC Configuration


### PR DESCRIPTION
Updated random_password resources for Postgres, MySQL, and RabbitMQ to set 'special' to false, preventing the use of special characters in generated passwords. This change avoids issues with certain special characters in service configurations.