### PR TITLE
Add in-cluster database manifests and update infra config

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -16,6 +16,8 @@ env:
   TF_VAR_aws_region: ${{ secrets.AWS_REGION }}
   TF_VAR_backend_bucket: ${{ secrets.TF_STATE_BUCKET }}
   TF_VAR_backend_bucket_key: ${{ secrets.TF_STATE_KEY }}
+  TF_VAR_cluster_name: ${{ secrets.TF_CLUSTER_NAME }}
+  TF_VAR_app_namespace: ${{ secrets.KUBE_APP_NAMESPACE }}
 
 jobs:
   validate:
@@ -96,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     if: github.ref == 'refs/heads/main' && (github.event.pull_request.merged == true || github.event_name == 'push')
+    outputs:
+      applied: ${{ steps.exec-apply.outputs.applied }}
 
     steps:
       - name: Checkout code
@@ -126,5 +130,45 @@ jobs:
         run: terraform plan -no-color
 
       - name: Terraform Apply
+        id: exec-apply
         working-directory: ${{ env.WORKING_DIRECTORY }}
-        run: terraform apply -auto-approve
+        run:
+          terraform apply -auto-approve
+          echo "applied=true" >> $GITHUB_OUTPUT
+  in-cluster-database-states:
+    needs: apply
+    environment: dev
+    name: Create In-Cluster Database States
+    runs-on: ubuntu-latest
+    if: needs.apply.outputs.applied == 'true'
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.28.0'
+      - name: Update kubeconfig
+        run: |
+          aws eks update-kubeconfig --region ${{ secrets.AWS_REGION }} --name ${{ secrets.TF_CLUSTER_NAME }}
+      - name: Verify cluster connection
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+      - name: Deploy Kubernetes manifests
+        run: |
+          kubectl apply -f database/ --namespace=${{ secrets.KUBE_APP_NAMESPACE }}
+      - name: Wait for deployments to be ready
+        run: |
+          echo "Waiting for StatefulSets to be ready..."
+          kubectl wait --for=condition=ready pod -l app=postgres --timeout=300s --namespace=${{ secrets.KUBE_APP_NAMESPACE }} || true
+          kubectl wait --for=condition=ready pod -l app=redis --timeout=300s --namespace=${{ secrets.KUBE_APP_NAMESPACE }} || true
+          kubectl wait --for=condition=ready pod -l app=mysql --timeout=300s --namespace=${{ secrets.KUBE_APP_NAMESPACE }} || true
+          kubectl wait --for=condition=ready pod -l app=dynamodb --timeout=300s --namespace=${{ secrets.KUBE_APP_NAMESPACE }} || true
+          kubectl wait --for=condition=ready pod -l app=rabbitmq --timeout=300s --namespace=${{ secrets.KUBE_APP_NAMESPACE }} || true
+          
+          

--- a/terraform/infra/database/manifest.yaml
+++ b/terraform/infra/database/manifest.yaml
@@ -1,0 +1,318 @@
+# Postgres Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app
+  labels:
+    name: app
+
+---
+# Postgres StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: app
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: database
+                  key: in_cluster_postgres_database
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: database
+                  key: in_cluster_postgres_username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database
+                  key: in_cluster_postgres_password
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+
+---
+# Postgres Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: app
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP
+
+---
+# Redis StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: app
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: redis-storage
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+
+---
+# Redis Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: app
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP
+
+---
+# MySQL StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: app
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database
+                  key: in_cluster_mysql_password
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: database
+                  key: in_cluster_mysql_database
+            - name: MYSQL_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: database
+                  key: in_cluster_mysql_username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database
+                  key: in_cluster_mysql_password
+          volumeMounts:
+            - name: mysql-storage
+              mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+
+---
+# MySQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: app
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+  type: ClusterIP
+
+---
+# DynamoDB StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dynamodb
+  namespace: app
+spec:
+  serviceName: dynamodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dynamodb
+  template:
+    metadata:
+      labels:
+        app: dynamodb
+    spec:
+      containers:
+        - name: dynamodb
+          image: amazon/dynamodb-local:latest
+          args:
+            - "-jar"
+            - "DynamoDBLocal.jar"
+            - "-sharedDb"
+            - "-dbPath"
+            - "/data"
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: dynamodb-storage
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: dynamodb-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+
+---
+# DynamoDB Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamodb
+  namespace: app
+spec:
+  selector:
+    app: dynamodb
+  ports:
+    - port: 8000
+      targetPort: 8000
+  type: ClusterIP
+
+---
+# RabbitMQ StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  namespace: app
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.12-management-alpine
+          ports:
+            - containerPort: 5672
+              name: amqp
+            - containerPort: 15672
+              name: management
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: database
+                  key: in_cluster_rabbitmq_username
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: database
+                  key: in_cluster_rabbitmq_password
+          volumeMounts:
+            - name: rabbitmq-storage
+              mountPath: /var/lib/rabbitmq
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+
+---
+# RabbitMQ Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: app
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - port: 5672
+      targetPort: 5672
+      name: amqp
+    - port: 15672
+      targetPort: 15672
+      name: management
+  type: ClusterIP

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -10,10 +10,17 @@ variable "app_namespace" {
   default     = "app"
 }
 
+variable "cluster_name" {
+  description = "Kubernetes cluster name"
+  type        = string
+  default     = "tinyuka-cluster"
+}
+
 locals {
-  rds_db_user = "tinyuka"
-  rds_db_name = "tinyuka_app"
-  app_name    = "tinyuka-cluster"
+  rds_db_user   = "tinyuka"
+  rds_db_name   = "tinyuka_app"
+  app_name      = "tinyuka-cluster"
+  rabbitmq_user = "tinyka"
 }
 
 terraform {
@@ -318,7 +325,7 @@ resource "aws_iam_openid_connect_provider" "eks" {
 
 # EKS Cluster
 resource "aws_eks_cluster" "main" {
-  name     = local.app_name
+  name     = var.cluster_name
   role_arn = aws_iam_role.eks_cluster.arn
   version  = "1.33"
 
@@ -996,7 +1003,7 @@ resource "kubernetes_config_map" "storage_config" {
 
     in_cluster_rabbitmq_port            = "5672"
     in_cluster_rabbitmq_management_port = "15672"
-    in_cluster_rabbitmq_username        = "rabbitmq_user"
+    in_cluster_rabbitmq_username        = local.rabbitmq_user
     in_cluster_rabbitmq_host            = "rabbitmq.${var.app_namespace}.svc.cluster.local"
   }
 
@@ -1028,9 +1035,9 @@ resource "kubernetes_secret" "storage_credentials" {
     in_cluster_postgres_password = random_password.postgres_password.result
     in_cluster_postgres_url      = "postgresql://${local.rds_db_user}:${random_password.postgres_password.result}@postgres.${var.app_namespace}.svc.cluster.local:5432/${local.rds_db_name}"
     in_cluster_mysql_password    = random_password.mysql_password.result
-    in_cluster_mysql_url         = "mysql://mysql_user:${random_password.mysql_password.result}@mysql.${var.app_namespace}.svc.cluster.local:3306/${local.rds_db_name}"
+    in_cluster_mysql_url         = "mysql://${local.rds_db_user}:${random_password.mysql_password.result}@mysql.${var.app_namespace}.svc.cluster.local:3306/${local.rds_db_name}"
     in_cluster_rabbitmq_password = random_password.rabbitmq_password.result
-    in_cluster_rabbitmq_url      = "amqp://rabbitmq_user:${random_password.rabbitmq_password.result}@rabbitmq.${var.app_namespace}.svc.cluster.local:5672"
+    in_cluster_rabbitmq_url      = "amqp://${local.rabbitmq_user}:${random_password.rabbitmq_password.result}@rabbitmq.${var.app_namespace}.svc.cluster.local:5672"
 
     # AWS DynamoDB connection info
     aws_dynamodb_endpoint = "https://dynamodb.${var.aws_region}.amazonaws.com"


### PR DESCRIPTION
Introduces Kubernetes manifests for in-cluster PostgreSQL, MySQL, Redis, DynamoDB, and RabbitMQ under the app namespace. Updates the GitHub Actions workflow to deploy these manifests post-Terraform apply. Refactors Terraform variables and locals for cluster naming and RabbitMQ user, and aligns README and resource references to use the new 'database' ConfigMap/Secret and updated service endpoints.