### PR TITLE
Add working directory to Kubernetes deploy step

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -161,6 +161,7 @@ jobs:
           kubectl get nodes
       - name: Deploy Kubernetes manifests
         run: |
+          working-directory: ${{ env.WORKING_DIRECTORY }}
           kubectl apply -f database/ --namespace=${{ secrets.KUBE_APP_NAMESPACE }}
       - name: Wait for deployments to be ready
         run: |


### PR DESCRIPTION
Set the working directory using the WORKING_DIRECTORY environment variable before applying Kubernetes manifests in the deployment workflow.