### PR TITLE
Add code checkout step to Terraform workflow

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -148,6 +148,8 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
         with:


### PR DESCRIPTION
Introduced a 'Checkout code' step using actions/checkout@v4 in the terraform-infra GitHub Actions workflow to ensure the repository code is available for subsequent steps.