### PR TITLE
Fix working-directory placement in deploy step

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -162,8 +162,8 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
       - name: Deploy Kubernetes manifests
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          working-directory: ${{ env.WORKING_DIRECTORY }}
           kubectl apply -f database/ --namespace=${{ secrets.KUBE_APP_NAMESPACE }}
       - name: Wait for deployments to be ready
         run: |


### PR DESCRIPTION
Moves the 'working-directory' property to the correct location in the 'Deploy Kubernetes manifests' step to ensure manifests are applied from the intended directory.