### PR TITLE
Update UI deployment and ingress health checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           kubectl create secret generic dynamo-access-config \
             --from-literal=access_key_id=${{ secrets.DYNAMO_AWS_ACCESS_KEY_ID }} \
             --from-literal=access_secret_key=${{ secrets.DYNAMO_AWS_SECRET_ACCESS_KEY }} \
-            --namespace=${{ secrets.KUBE_APP_NAMESPACE }}
+            --namespace=${{ secrets.KUBE_APP_NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
       - name: Deploy Kubernetes manifests
         run: |

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
       }}
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-1:396768595839:certificate/4a27bba5-f791-42a3-a555-08d9598c97a2
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
 spec:
   ingressClassName: alb
   rules:

--- a/manifests/ui.app.yaml
+++ b/manifests/ui.app.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: ui
-          image: public.ecr.aws/aws-containers/retail-store-sample-ui:1.2.4
+          image: public.ecr.aws/aws-containers/retail-store-sample-ui:1.3.0-amd64
           ports:
             - containerPort: 8080
           env:
@@ -51,26 +51,30 @@ spec:
             - name: RETAIL_UI_DISABLE_DEMO_WARNINGS
               value: 'false'
             - name: RETAIL_UI_ENDPOINTS_CATALOG
-              value: 'http://catalog.app'
+              value: 'http://catalog.app.svc.cluster.local:8080'
             - name: RETAIL_UI_ENDPOINTS_CARTS
-              value: 'http://cart.app'
+              value: 'http://cart.app.svc.cluster.local:8080'
             - name: RETAIL_UI_ENDPOINTS_ORDERS
-              value: 'http://orders.app'
+              value: 'http://orders.app.svc.cluster.local:8080'
             - name: RETAIL_UI_ENDPOINTS_CHECKOUT
-              value: 'http://checkout.app'
+              value: 'http://checkout.app.svc.cluster.local:8080'
+            - name: SERVER_TOMCAT_ACCESSLOG_ENABLED
+              value: 'true'
+            - name: AWS_REGION
+              value: 'eu-west-1'
           readinessProbe:
             httpGet:
-              path: /health
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30
-            timeoutSeconds: 10
+            timeoutSeconds: 30
             failureThreshold: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 30
             failureThreshold: 3


### PR DESCRIPTION
Upgraded UI container image to v1.3.0-amd64 and updated service endpoints to use cluster-local addresses with explicit ports. Added SERVER_TOMCAT_ACCESSLOG_ENABLED and AWS_REGION environment variables. Changed readiness and liveness probes to use /actuator/health and increased their timeouts. In ingress.yaml, added health check path and port annotations for ALB. Minor fix in deploy workflow for secret creation command.