### PR TITLE
Update host and certificate for ingress and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Cluster Overview
 > **Name**: tinyuka-cluster  
 > **Region**: eu-west-1  
-> **Host Location**: [tinyuka-mart.run.place](https://tinyuka-mart.run.place)
+> **Host Location**: [store.tinyuka-mart.run.place](https://store.tinyuka-mart.run.place)
 
 A comprehensive, production-ready AWS EKS infrastructure with both AWS managed services and in-cluster alternatives, built with Terraform and automated via GitHub Actions.
 

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -12,14 +12,14 @@ metadata:
         "Port": "443",
         "StatusCode": "HTTP_301"
       }}
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-1:396768595839:certificate/4a27bba5-f791-42a3-a555-08d9598c97a2
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-1:396768595839:certificate/1deebaa6-ecbf-4703-b494-ce98e54edfc2
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port
 spec:
   ingressClassName: alb
   rules:
-    - host: tinyuka-mart.run.place
+    - host: store.tinyuka-mart.run.place
       http:
         paths:
           - path: /


### PR DESCRIPTION
Changed the host from tinyuka-mart.run.place to store.tinyuka-mart.run.place in both README and ingress.yaml. Updated the ALB certificate ARN in ingress.yaml to match the new host.